### PR TITLE
Fix location abbr length

### DIFF
--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -51,7 +51,7 @@ class Location extends BaseModel
             }
             if (empty($location->abbreviation)) {
                 do {
-                    $abbreviation = Str::upper(Str::limit(Str::slug($location->name), 3)) . Str::upper(Str::random(1));
+                    $abbreviation = Str::upper(Str::substr(Str::slug($location->name), 0, 3)) . Str::upper(Str::random(1));
                 } while (self::where('abbreviation', $abbreviation)->first()); //check if the token already exists and if it does, try again
                 $location->abbreviation = $abbreviation;
             }


### PR DESCRIPTION
Fix for mysql field length issue (`Str::limit` adds truncation characters - `MOH...G`):
```
  SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'abbreviation' at row 1 (SQL: insert into `locations` (`name`, `slug`, `title_part`, `timezone`, `market_id`, `creator_id`, `updater_id`, `contact_email`, `abbreviation`, `updated_at`, `created_at`) values (Mohamedville, mohamedville, Mohamedville, America/Bahia_Banderas, 1, 1, 1, mohamedville@thegreatescaperoom.com, MOH...G, 2021-03-04 19:31:35, 2021-03-04 19:31:35))
```