### PR TITLE
Add web routes for market, location pages.  Add Route::getLocation macro #85

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "tipoff/authorization": "^2.6.2",
         "tipoff/laravel-google-api": "^1.3.3",
         "tipoff/seo": "^2.4.0",
-        "tipoff/support": "^1.8.5"
+        "tipoff/support": "dev-pdbreen/feature/locations-85 as 1.8.5"
     },
     "require-dev": {
         "tipoff/test-support": "^1.3.0"

--- a/config/locations.php
+++ b/config/locations.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'invalid_slugs' => ['company', 'about-us'],
+
     'service_class' => [
 
         'calendar' => \App\Services\CalendarService::class

--- a/resources/views/location.blade.php
+++ b/resources/views/location.blade.php
@@ -1,0 +1,5 @@
+@extends('support::layout')
+
+@section('content')
+    {{ $market->name }} : {{ $location->name }}
+@endsection

--- a/resources/views/location_select.blade.php
+++ b/resources/views/location_select.blade.php
@@ -1,0 +1,12 @@
+@extends('support::layout')
+
+@section('content')
+    <h3>Select Location @if($market)for {{ $market->name }}@endif</h3>
+    <ul>
+    @foreach($locations as $location)
+        <li>
+            <a href="{{ route('location', ['market' => $location->market, 'location' => $location]) }}">{{ $location->name }}</a>
+        </li>
+    @endforeach
+    </ul>
+@endsection

--- a/resources/views/market.blade.php
+++ b/resources/views/market.blade.php
@@ -1,0 +1,5 @@
+@extends('support::layout')
+
+@section('content')
+    {{ $market->name }}
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Tipoff\Locations\Http\Controllers\LocationController;
+use Tipoff\Locations\Http\Controllers\MarketController;
+use Tipoff\Locations\Http\Middleware\ResolveLocation;
+
+Route::middleware(config('tipoff.web.middleware_group'))
+    ->prefix(config('tipoff.web.uri_prefix'))
+    ->group(function () {
+
+        Route::get('{market}/{location}', LocationController::class)
+            ->name('location');
+
+        Route::get('{market}', MarketController::class)
+            ->name('market');
+    });

--- a/src/Exceptions/LocationException.php
+++ b/src/Exceptions/LocationException.php
@@ -3,8 +3,6 @@
 
 namespace Tipoff\Locations\Exceptions;
 
-
 interface LocationException
 {
-
 }

--- a/src/Exceptions/LocationException.php
+++ b/src/Exceptions/LocationException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Tipoff\Locations\Exceptions;
+
+
+interface LocationException
+{
+
+}

--- a/src/Exceptions/UnresolvedLocation.php
+++ b/src/Exceptions/UnresolvedLocation.php
@@ -7,37 +7,19 @@ namespace Tipoff\Locations\Exceptions;
 use Exception;
 use Tipoff\Locations\Models\Market;
 
-class UnresolvedLocation extends Exception
+class UnresolvedLocation extends Exception implements LocationException
 {
     protected $market;
 
     public function __construct(Market $market)
     {
-        parent::__construct("Could not resolve location for { $market->toJson() }");
+        parent::__construct("Could not resolve location for { $market->name }");
 
         $this->market = $market;
     }
 
     public function render()
     {
-        if (view()->exists('website.markets.select')) {
-            return view('website.markets.select', [
-                'market' => $this->market,
-                'html' => null,
-                'seotitle' => $this->market->title,
-                'seodescription' => "{ $this->market->title } has { $this->market->rooms->count() } different escape rooms and offers private escape games for groups & parties. Book your escape room today!",
-                'ogtitle' => $this->market->title,
-                'ogdescription' => "{ $this->market->title } has { $this->market->rooms->count() } different escape rooms and offers private escape games for groups & parties. Book your escape room today!",
-                // TODO - tipoff specific helper for canonical url?
-                'canonical' => url($this->market->bookings_path),
-                'image' => $this->market->image_id === null ? null : $this->market->image,
-                // TODO - default image from config/tipoff.php?
-                'ogimage' => $this->market->ogimage_id === null ? url('public/img/ogimage.png') : $this->market->ogimage,
-            ]);
-        }
-
-        // If view doesnt exist, repackage and rethrow new exception
-        // TODO - this may not work.  Might be too late for this.
-        throw new Exception($this->getMessage(), $this->code, $this);
+        return view('locations::location_select');
     }
 }

--- a/src/Exceptions/UnresolvedMarket.php
+++ b/src/Exceptions/UnresolvedMarket.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Locations\Exceptions;
+
+use Exception;
+
+class UnresolvedMarket extends Exception implements LocationException
+{
+    public function __construct()
+    {
+        parent::__construct("Could not resolve market");
+    }
+
+    public function render()
+    {
+        return view('locations::location_select');
+    }
+}

--- a/src/Http/Controllers/LocationController.php
+++ b/src/Http/Controllers/LocationController.php
@@ -13,6 +13,17 @@ class LocationController extends BaseController
 {
     public function __invoke(Request $request, Market $market, Location $location)
     {
+        if ($market->locations()->count() === 1) {
+            if (Market::query()->count() === 1) {
+                // Single location, single market => go home
+                return redirect('/');
+            }
+
+            // Single location, multiple markets => go to market home
+            return redirect(route('market', ['market' => $market]));
+        }
+
+        // Location home
         return view('locations::location', [
             'market' => $market,
             'location' => $location,

--- a/src/Http/Controllers/LocationController.php
+++ b/src/Http/Controllers/LocationController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Locations\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Tipoff\Locations\Models\Location;
+use Tipoff\Locations\Models\Market;
+use Tipoff\Support\Http\Controllers\BaseController;
+
+class LocationController extends BaseController
+{
+    public function __invoke(Request $request, Market $market, Location $location)
+    {
+        return view('locations::location', [
+            'market' => $market,
+            'location' => $location,
+        ]);
+    }
+}

--- a/src/Http/Controllers/MarketController.php
+++ b/src/Http/Controllers/MarketController.php
@@ -12,6 +12,12 @@ class MarketController extends BaseController
 {
     public function __invoke(Request $request, Market $market)
     {
+        if ($market->locations()->count() === 1 &&
+            Market::query()->count() === 1) {
+            // Single location, single market => go home
+            return redirect('/');
+        }
+
         return view('locations::market', [
             'market' => $market
         ]);

--- a/src/Http/Controllers/MarketController.php
+++ b/src/Http/Controllers/MarketController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Locations\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Tipoff\Locations\Models\Market;
+use Tipoff\Support\Http\Controllers\BaseController;
+
+class MarketController extends BaseController
+{
+    public function __invoke(Request $request, Market $market)
+    {
+        return view('locations::market', [
+            'market' => $market
+        ]);
+    }
+}

--- a/src/Http/Controllers/MarketController.php
+++ b/src/Http/Controllers/MarketController.php
@@ -13,7 +13,7 @@ class MarketController extends BaseController
     public function __invoke(Request $request, Market $market)
     {
         return view('locations::market', [
-            'market' => $market
+            'market' => $market,
         ]);
     }
 }

--- a/src/Http/Middleware/ResolveLocation.php
+++ b/src/Http/Middleware/ResolveLocation.php
@@ -8,6 +8,7 @@ use Closure;
 use Tipoff\Locations\Models\Location;
 use Tipoff\Locations\Models\Market;
 use Tipoff\Locations\Services\LocationResolver;
+use Tipoff\Locations\Services\MarketResolver;
 
 class ResolveLocation
 {
@@ -20,16 +21,13 @@ class ResolveLocation
      */
     public function handle($request, Closure $next)
     {
-        $market = $request->route()->parameter('market');
-        $location = $request->route()->parameter('location');
+        $market = app(MarketResolver::class)->resolve($request->route('market'));
+        $request->route()->setParameter('market', $market);
+
+        $location = app(LocationResolver::class)->resolve($market, $request->route('location'));
+        $request->route()->setParameter('location', $location);
 
         $this->ensureLocationBelongsToMarket($market, $location);
-
-        if (! $location) {
-            $location = (new LocationResolver)->resolve($market);
-
-            $request->route()->setParameter('location', $location);
-        }
 
         return $next($request);
     }

--- a/src/Models/Market.php
+++ b/src/Models/Market.php
@@ -7,6 +7,7 @@ namespace Tipoff\Locations\Models;
 use DrewRoberts\Media\Traits\HasMedia;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use Tipoff\Support\Models\BaseModel;
 use Tipoff\Support\Traits\HasCreator;
 use Tipoff\Support\Traits\HasPackageFactory;
@@ -32,6 +33,14 @@ class Market extends BaseModel
     protected static function boot()
     {
         parent::boot();
+
+        static::creating(function (Market $market) {
+            $market->slug = $market->slug ?: Str::slug($market->city);
+            $invalidSlugs = config('locations.invalid_slugs') ?? [];
+            if (in_array($market->slug, $invalidSlugs)) {
+                $market->slug = Str::slug("{$market->slug}-{$market->state}");
+            }
+        });
 
         static::saving(function ($market) {
             if (empty($market->entered_at)) {

--- a/src/Services/LocationResolver.php
+++ b/src/Services/LocationResolver.php
@@ -5,17 +5,32 @@ declare(strict_types=1);
 namespace Tipoff\Locations\Services;
 
 use Tipoff\Locations\Exceptions\UnresolvedLocation;
+use Tipoff\Locations\Http\Middleware\ResolveLocation;
 use Tipoff\Locations\Models\Location;
 use Tipoff\Locations\Models\Market;
 
 class LocationResolver
 {
-    public function resolve(Market $market): Location
+    const TIPOFF_LOCATION = 'tipoff.location';
+
+    public static function location(): ?Location
     {
-        if ($market->locations->count() !== 1) {
-            throw new UnresolvedLocation($market);
+        return app()->has(self::TIPOFF_LOCATION) ? app(self::TIPOFF_LOCATION) : null;
+    }
+
+    public function resolve(?Market $market = null, $location = null): Location
+    {
+        $location = $location ?? static::location();
+        if (!$location instanceof Location) {
+            $market = $market ?: app(MarketResolver::class)->resolve();
+            if ($market->locations()->count() !== 1) {
+                throw new UnresolvedLocation($market);
+            }
+
+            $location = $market->locations->first();
         }
 
-        return $market->locations->first();
+        app()->instance(self::TIPOFF_LOCATION, $location);
+        return $location;
     }
 }

--- a/src/Services/LocationResolver.php
+++ b/src/Services/LocationResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tipoff\Locations\Services;
 
 use Tipoff\Locations\Exceptions\UnresolvedLocation;
-use Tipoff\Locations\Http\Middleware\ResolveLocation;
 use Tipoff\Locations\Models\Location;
 use Tipoff\Locations\Models\Market;
 
@@ -21,7 +20,7 @@ class LocationResolver
     public function resolve(?Market $market = null, $location = null): Location
     {
         $location = $location ?? static::location();
-        if (!$location instanceof Location) {
+        if (! $location instanceof Location) {
             $market = $market ?: app(MarketResolver::class)->resolve();
             if ($market->locations()->count() !== 1) {
                 throw new UnresolvedLocation($market);
@@ -31,6 +30,7 @@ class LocationResolver
         }
 
         app()->instance(self::TIPOFF_LOCATION, $location);
+
         return $location;
     }
 }

--- a/src/Services/LocationRouter.php
+++ b/src/Services/LocationRouter.php
@@ -9,15 +9,24 @@ use Tipoff\Locations\Models\Market;
 
 class LocationRouter
 {
-    public static function build(string $routeName, Market $market, Location $location): string
+    public static function build(string $routeName, ?Location $location = null): string
     {
-        if ($market->locations->count() !== 1) {
-            return route($routeName, [
-                $market,
-                $location,
+        /** @var Location $location */
+        $location = $location ?: app(LocationResolver::TIPOFF_LOCATION);
+        $market = $location->market;
+        if ($market->locations()->count() !== 1) {
+            return route('market.location.'.$routeName, [
+                'market' => $market,
+                'location' => $location,
             ]);
         }
 
-        return route($routeName, $market);
+        if (Market::query()->count() !== 1) {
+            return route('market.'.$routeName, [
+                'market' => $market,
+            ]);
+        }
+
+        return route($routeName);
     }
 }

--- a/src/Services/MarketResolver.php
+++ b/src/Services/MarketResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tipoff\Locations\Services;
 
 use Tipoff\Locations\Exceptions\UnresolvedMarket;
-use Tipoff\Locations\Http\Middleware\ResolveLocation;
 use Tipoff\Locations\Models\Market;
 
 class MarketResolver
@@ -20,7 +19,7 @@ class MarketResolver
     public function resolve($market = null): Market
     {
         $market = $market ?? static::market();
-        if (!$market instanceof Market) {
+        if (! $market instanceof Market) {
             if (Market::query()->count() !== 1) {
                 throw new UnresolvedMarket();
             }
@@ -29,6 +28,7 @@ class MarketResolver
         }
 
         app()->instance(self::TIPOFF_MARKET, $market);
+
         return $market;
     }
 }

--- a/src/Services/MarketResolver.php
+++ b/src/Services/MarketResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Locations\Services;
+
+use Tipoff\Locations\Exceptions\UnresolvedMarket;
+use Tipoff\Locations\Http\Middleware\ResolveLocation;
+use Tipoff\Locations\Models\Market;
+
+class MarketResolver
+{
+    const TIPOFF_MARKET = 'tipoff.market';
+
+    public static function market(): ?Market
+    {
+        return app()->has(self::TIPOFF_MARKET) ? app(self::TIPOFF_MARKET) : null;
+    }
+
+    public function resolve($market = null): Market
+    {
+        $market = $market ?? static::market();
+        if (!$market instanceof Market) {
+            if (Market::query()->count() !== 1) {
+                throw new UnresolvedMarket();
+            }
+
+            $market = Market::query()->firstOrFail();
+        }
+
+        app()->instance(self::TIPOFF_MARKET, $market);
+        return $market;
+    }
+}

--- a/src/ViewComposers/LocationSelectComposer.php
+++ b/src/ViewComposers/LocationSelectComposer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Locations\ViewComposers;
+
+use Tipoff\Locations\Models\Location;
+use Tipoff\Locations\Services\MarketResolver;
+
+class LocationSelectComposer
+{
+    public function compose($view)
+    {
+        $market = MarketResolver::market();
+        $locations = $market ? $market->locations : Location::all();
+
+        $view->with([
+            'market' => $market,
+            'locations' => $locations,
+        ]);
+    }
+}

--- a/tests/Unit/Http/Controllers/LocationControllerTest.php
+++ b/tests/Unit/Http/Controllers/LocationControllerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Locations\Tests\Unit\Http\Controllers;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Locations\Models\Location;
+use Tipoff\Locations\Tests\TestCase;
+
+class LocationControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function index()
+    {
+        $location = Location::factory()->create();
+        $market = $location->market;
+
+        $prefix = config('tipoff.web.uri_prefix');
+        $this->get("{$prefix}/{$market->slug}/{$location->slug}")
+            ->assertOk()
+            ->assertSee($location->name)
+            ->assertSee($market->name);
+    }
+}

--- a/tests/Unit/Http/Controllers/LocationControllerTest.php
+++ b/tests/Unit/Http/Controllers/LocationControllerTest.php
@@ -6,6 +6,7 @@ namespace Tipoff\Locations\Tests\Unit\Http\Controllers;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tipoff\Locations\Models\Location;
+use Tipoff\Locations\Models\Market;
 use Tipoff\Locations\Tests\TestCase;
 
 class LocationControllerTest extends TestCase
@@ -13,10 +14,24 @@ class LocationControllerTest extends TestCase
     use DatabaseTransactions;
 
     /** @test */
-    public function index()
+    public function index_single_market_single_location()
     {
         $location = Location::factory()->create();
         $market = $location->market;
+
+        $prefix = config('tipoff.web.uri_prefix');
+        $this->get("{$prefix}/{$market->slug}/{$location->slug}")
+            ->assertRedirect('/');
+    }
+
+    /** @test */
+    public function index_single_market_multiple_locations()
+    {
+        $market = Market::factory()->create();
+
+        $location = Location::factory()->count(2)->create([
+            'market_id' => $market,
+        ])->first();
 
         $prefix = config('tipoff.web.uri_prefix');
         $this->get("{$prefix}/{$market->slug}/{$location->slug}")
@@ -24,4 +39,18 @@ class LocationControllerTest extends TestCase
             ->assertSee($location->name)
             ->assertSee($market->name);
     }
+
+    /** @test */
+    public function index_multiple_markets_single_locations()
+    {
+        $location = Location::factory()->count(3)->create([
+            'market_id' => function () { return Market::factory()->create(); },
+        ])->first();
+        $market = $location->market;
+
+        $prefix = config('tipoff.web.uri_prefix');
+        $this->get("{$prefix}/{$market->slug}/{$location->slug}")
+            ->assertRedirect("{$prefix}/{$market->slug}");
+    }
+
 }

--- a/tests/Unit/Http/Controllers/LocationControllerTest.php
+++ b/tests/Unit/Http/Controllers/LocationControllerTest.php
@@ -44,7 +44,9 @@ class LocationControllerTest extends TestCase
     public function index_multiple_markets_single_locations()
     {
         $location = Location::factory()->count(3)->create([
-            'market_id' => function () { return Market::factory()->create(); },
+            'market_id' => function () {
+                return Market::factory()->create();
+            },
         ])->first();
         $market = $location->market;
 
@@ -52,5 +54,4 @@ class LocationControllerTest extends TestCase
         $this->get("{$prefix}/{$market->slug}/{$location->slug}")
             ->assertRedirect("{$prefix}/{$market->slug}");
     }
-
 }

--- a/tests/Unit/Http/Controllers/MarketControllerTest.php
+++ b/tests/Unit/Http/Controllers/MarketControllerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Locations\Tests\Unit\Http\Controllers;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Locations\Models\Location;
+use Tipoff\Locations\Tests\TestCase;
+
+class MarketControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function index()
+    {
+        $location = Location::factory()->create();
+        $market = $location->market;
+
+        $prefix = config('tipoff.web.uri_prefix');
+        $this->get("{$prefix}/{$market->slug}")
+            ->assertOk()
+            ->assertDontSee($location->name)
+            ->assertSee($market->name);
+    }
+}

--- a/tests/Unit/Http/Controllers/MarketControllerTest.php
+++ b/tests/Unit/Http/Controllers/MarketControllerTest.php
@@ -6,6 +6,7 @@ namespace Tipoff\Locations\Tests\Unit\Http\Controllers;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tipoff\Locations\Models\Location;
+use Tipoff\Locations\Models\Market;
 use Tipoff\Locations\Tests\TestCase;
 
 class MarketControllerTest extends TestCase
@@ -13,9 +14,38 @@ class MarketControllerTest extends TestCase
     use DatabaseTransactions;
 
     /** @test */
-    public function index()
+    public function index_single_market_single_location()
     {
         $location = Location::factory()->create();
+        $market = $location->market;
+
+        $prefix = config('tipoff.web.uri_prefix');
+        $this->get("{$prefix}/{$market->slug}")
+            ->assertRedirect('/');
+    }
+
+    /** @test */
+    public function index_single_market_multiple_locations()
+    {
+        $market = Market::factory()->create();
+
+        $location = Location::factory()->count(2)->create([
+            'market_id' => $market,
+        ])->first();
+
+        $prefix = config('tipoff.web.uri_prefix');
+        $this->get("{$prefix}/{$market->slug}")
+            ->assertOk()
+            ->assertDontSee($location->name)
+            ->assertSee($market->name);
+    }
+
+    /** @test */
+    public function index_multiple_markets_single_locations()
+    {
+        $location = Location::factory()->count(3)->create([
+            'market_id' => function () { return Market::factory()->create(); },
+        ])->first();
         $market = $location->market;
 
         $prefix = config('tipoff.web.uri_prefix');

--- a/tests/Unit/Http/Controllers/MarketControllerTest.php
+++ b/tests/Unit/Http/Controllers/MarketControllerTest.php
@@ -44,7 +44,9 @@ class MarketControllerTest extends TestCase
     public function index_multiple_markets_single_locations()
     {
         $location = Location::factory()->count(3)->create([
-            'market_id' => function () { return Market::factory()->create(); },
+            'market_id' => function () {
+                return Market::factory()->create();
+            },
         ])->first();
         $market = $location->market;
 

--- a/tests/Unit/Http/Middleware/ResolveLocationTest.php
+++ b/tests/Unit/Http/Middleware/ResolveLocationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Locations\Tests\Unit\Http\Middleware;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Route;
+use Tipoff\Locations\Models\Location;
+use Tipoff\Locations\Models\Market;
+use Tipoff\Locations\Services\LocationRouter;
+use Tipoff\Locations\Tests\TestCase;
+
+class ResolveLocationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function single_market_single_location()
+    {
+        $this->logToStderr();
+        Route::getLocation('test', 'test', function () {
+            return LocationRouter::build('test');
+        });
+
+        $location = Location::factory()->create();
+        $market = $location->market;
+
+        $this->get('company/test')
+            ->assertOk()
+            ->assertSee("http://localhost/company/test");
+
+        $this->get("{$market->slug}/test")
+            ->assertOk()
+            ->assertSee("http://localhost/company/test");
+
+        $this->get("{$market->slug}/{$location->slug}/test")
+            ->assertOk()
+            ->assertSee("http://localhost/company/test");
+    }
+
+    /** @test */
+    public function multiple_markets_single_locations()
+    {
+        Route::getLocation('test', 'test', function () {
+            return LocationRouter::build('test');
+        });
+
+        Market::factory()->count(2)->create()
+            ->each(function (Market $market) {
+                Location::factory()->create([
+                    'market_id' => $market,
+                ]);
+            });
+
+        $location = Location::query()->first();
+        $market = $location->market;
+
+        $this->get("company/test")
+            ->assertOk()
+            ->assertSee("Select Location");
+
+        $this->get("{$market->slug}/test")
+            ->assertOk()
+            ->assertSee("http://localhost/{$market->slug}/test");
+
+        $this->get("{$market->slug}/{$location->slug}/test")
+            ->assertOk()
+            ->assertSee("http://localhost/{$market->slug}/test");
+    }
+
+    /** @test */
+    public function multiple_markets_multiple_locations()
+    {
+        Route::getLocation('test', 'test', function () {
+            return LocationRouter::build('test');
+        });
+
+        Market::factory()->count(2)->create()
+            ->each(function (Market $market) {
+                Location::factory()->count(2)->create([
+                    'market_id' => $market,
+                ]);
+            });
+
+        $location = Location::query()->first();
+        $market = $location->market;
+
+        $this->get("company/test")
+            ->assertOk()
+            ->assertSee("Select Location");
+
+        $this->get("{$market->slug}/test")
+            ->assertOk()
+            ->assertSee("Select Location for {$market->name}");
+
+        $this->get("{$market->slug}/{$location->slug}/test")
+            ->assertOk()
+            ->assertSee("http://localhost/{$market->slug}/{$location->slug}/test");
+    }
+}

--- a/tests/Unit/Models/MarketTest.php
+++ b/tests/Unit/Models/MarketTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tipoff\Locations\Tests\Unit\Models;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Str;
 use Tipoff\Locations\Models\Market;
 use Tipoff\Locations\Tests\TestCase;
 
@@ -17,5 +18,23 @@ class MarketTest extends TestCase
     {
         $model = Market::factory()->create();
         $this->assertNotNull($model);
+    }
+
+    /** @test */
+    public function default_slug()
+    {
+        $market = Market::factory()->create([
+            'slug' => null,
+        ]);
+        $this->assertEquals(Str::slug($market->city), $market->slug);
+    }
+
+    /** @test */
+    public function restricted_slug()
+    {
+        $market = Market::factory()->create([
+            'slug' => 'company',
+        ]);
+        $this->assertEquals(Str::slug("company-{$market->state}"), $market->slug);
     }
 }

--- a/tests/Unit/Services/LocationResolverTest.php
+++ b/tests/Unit/Services/LocationResolverTest.php
@@ -18,7 +18,7 @@ class LocationResolverTest extends TestCase
     /** @test */
     public function resolve_with_single_locations()
     {
-        $market = Market::factory()->create();
+        $market = Market::factory()->count(2)->create()->first();
         $location = Location::factory()->create([
             'market_id' => $market,
         ]);

--- a/tests/Unit/Services/MarketResolverTest.php
+++ b/tests/Unit/Services/MarketResolverTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Locations\Tests\Unit\Services;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Locations\Exceptions\UnresolvedMarket;
+use Tipoff\Locations\Models\Market;
+use Tipoff\Locations\Services\MarketResolver;
+use Tipoff\Locations\Tests\TestCase;
+
+class MarketResolverTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function resolve_with_single_market()
+    {
+        $market = Market::factory()->create();
+
+        $result = (new MarketResolver())->resolve();
+        $this->assertEquals($market->id, $result->id);
+    }
+
+    /** @test */
+    public function fail_with_no_markets()
+    {
+        $this->expectException(UnresolvedMarket::class);
+
+        (new MarketResolver)->resolve();
+    }
+
+    /** @test */
+    public function fail_with_multiple_markets()
+    {
+        $market = Market::factory()->count(2)->create();
+
+        $this->expectException(UnresolvedMarket::class);
+
+        (new MarketResolver)->resolve();
+    }
+}

--- a/tests/Unit/ViewComposers/LocationSelectComposerTest.php
+++ b/tests/Unit/ViewComposers/LocationSelectComposerTest.php
@@ -33,7 +33,7 @@ class LocationSelectComposerTest extends TestCase
     {
         $markets = Market::factory()->count(2)->create()->each(function (Market $market) {
             Location::factory()->count(2)->create([
-                'market_id' => $market
+                'market_id' => $market,
             ]);
         });
 

--- a/tests/Unit/ViewComposers/LocationSelectComposerTest.php
+++ b/tests/Unit/ViewComposers/LocationSelectComposerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Locations\Tests\Unit\ViewComposers;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\View\View;
+use Tipoff\Locations\Models\Location;
+use Tipoff\Locations\Models\Market;
+use Tipoff\Locations\Tests\TestCase;
+
+class LocationSelectComposerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function no_market_context()
+    {
+        Location::factory()->count(4)->create();
+
+        /** @var View $view */
+        $view = view('locations::location_select');
+        $view->render(function (View $view) {
+            $data = $view->getData();
+            $this->assertNull($data['market']);
+            $this->assertCount(4, $data['locations']);
+        });
+    }
+
+    /** @test */
+    public function with_market_context()
+    {
+        $markets = Market::factory()->count(2)->create()->each(function (Market $market) {
+            Location::factory()->count(2)->create([
+                'market_id' => $market
+            ]);
+        });
+
+        $market = $markets->first();
+        $this->app->instance('tipoff.market', $market);
+
+        /** @var View $view */
+        $view = view('locations::location_select');
+        $view->render(function (View $view) use ($market) {
+            $data = $view->getData();
+            $this->assertEquals($market->id, $data['market']->id);
+            $this->assertCount(2, $data['locations']);
+        });
+    }
+}


### PR DESCRIPTION
* [x] requires updated tipoff/support containing `view/layout.blade.php` prior to merge

---

Adds routes
- {prefix}/{market->slug}/{location->slug} => view(locations::location)
- {prefix}/{market->slug} => view(locations::market)

Fixes `ResolveLocation` middleware to work properly in package (must be applied after SubstituteBindings).  Exceptions from failure to properly resolve route due to market or location ambiguity get rendered as a view(locations::location_select) with either a full or market constrained list of locations.

Adds `MarketResolver` to support single market scenario.  Updates `LocationResolver` and `MarketResolver` to store resolved market and location in application container.  Each resolver has a static helper method to fetch Market or Location from the container or null if no context exists.

Adds `Route::getLocation($routeName, $uri, $action)` macro that should be used to properly register all route variations of a location dependent page.  The action controller can have a `Location $location` parameter (and `Market $market` - but market can always be obtained from location).  

Updates `LocationRouter::build($routeName, $location)` to build the appropriate type of URL based on market/location ambiguity that exists.  The `$location` parameter can be omitted to use the current location in context.