### PR TITLE
Make market / location detail routes distinct

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -9,9 +9,9 @@ Route::middleware(config('tipoff.web.middleware_group'))
     ->prefix(config('tipoff.web.uri_prefix'))
     ->group(function () {
 
-        Route::get('{market}/{location}', LocationController::class)
+        Route::get('{market}/{location}/detail', LocationController::class)
             ->name('location');
 
-        Route::get('{market}', MarketController::class)
+        Route::get('{market}/detail', MarketController::class)
             ->name('market');
     });

--- a/tests/Unit/Http/Controllers/LocationControllerTest.php
+++ b/tests/Unit/Http/Controllers/LocationControllerTest.php
@@ -20,7 +20,7 @@ class LocationControllerTest extends TestCase
         $market = $location->market;
 
         $prefix = config('tipoff.web.uri_prefix');
-        $this->get("{$prefix}/{$market->slug}/{$location->slug}")
+        $this->get("{$prefix}/{$market->slug}/{$location->slug}/detail")
             ->assertRedirect('/');
     }
 
@@ -34,7 +34,7 @@ class LocationControllerTest extends TestCase
         ])->first();
 
         $prefix = config('tipoff.web.uri_prefix');
-        $this->get("{$prefix}/{$market->slug}/{$location->slug}")
+        $this->get("{$prefix}/{$market->slug}/{$location->slug}/detail")
             ->assertOk()
             ->assertSee($location->name)
             ->assertSee($market->name);
@@ -51,7 +51,7 @@ class LocationControllerTest extends TestCase
         $market = $location->market;
 
         $prefix = config('tipoff.web.uri_prefix');
-        $this->get("{$prefix}/{$market->slug}/{$location->slug}")
-            ->assertRedirect("{$prefix}/{$market->slug}");
+        $this->get("{$prefix}/{$market->slug}/{$location->slug}/detail")
+            ->assertRedirect("{$prefix}/{$market->slug}/detail");
     }
 }

--- a/tests/Unit/Http/Controllers/MarketControllerTest.php
+++ b/tests/Unit/Http/Controllers/MarketControllerTest.php
@@ -20,7 +20,7 @@ class MarketControllerTest extends TestCase
         $market = $location->market;
 
         $prefix = config('tipoff.web.uri_prefix');
-        $this->get("{$prefix}/{$market->slug}")
+        $this->get("{$prefix}/{$market->slug}/detail")
             ->assertRedirect('/');
     }
 
@@ -34,7 +34,7 @@ class MarketControllerTest extends TestCase
         ])->first();
 
         $prefix = config('tipoff.web.uri_prefix');
-        $this->get("{$prefix}/{$market->slug}")
+        $this->get("{$prefix}/{$market->slug}/detail")
             ->assertOk()
             ->assertDontSee($location->name)
             ->assertSee($market->name);
@@ -51,7 +51,7 @@ class MarketControllerTest extends TestCase
         $market = $location->market;
 
         $prefix = config('tipoff.web.uri_prefix');
-        $this->get("{$prefix}/{$market->slug}")
+        $this->get("{$prefix}/{$market->slug}/detail")
             ->assertOk()
             ->assertDontSee($location->name)
             ->assertSee($market->name);


### PR DESCRIPTION
Temp fix - prevent market / location detail routes from matching any one or two segment URL.