### PR TITLE
Updates to Location Nova resource

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.4|^8.0",
         "drewroberts/blog": "^4.4.2",
         "tipoff/authorization": "^2.8.0",
-        "tipoff/support": "^2.0.1"
+        "tipoff/support": "^2.0.2"
     },
     "require-dev": {
         "tipoff/test-support": "^2.0.0"

--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -66,8 +66,7 @@ class Location extends BaseModel
                     $abbreviation = Str::upper(Str::substr(Str::slug($location->name), 0, 3)) . Str::upper(Str::random(1));
                 } while (self::where('abbreviation', $abbreviation)->first()); //check if the token already exists and if it does, try again
                 $location->abbreviation = strtoupper($abbreviation);
-            }
-            else {
+            } else {
                 $location->abbreviation = strtoupper($location->abbreviation);
             }
         });

--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -60,13 +60,15 @@ class Location extends BaseModel
                 ->that($location->market_id)->notEmpty('A location must be in a market.')
                 ->verifyNow();
             $location->timezone_id = $location->timezone_id ?: $location->market->timezone->id;
-            $location->abbreviation = strtoupper($location->abbreviation);
 
             if (empty($location->abbreviation)) {
                 do {
                     $abbreviation = Str::upper(Str::substr(Str::slug($location->name), 0, 3)) . Str::upper(Str::random(1));
                 } while (self::where('abbreviation', $abbreviation)->first()); //check if the token already exists and if it does, try again
-                $location->abbreviation = $abbreviation;
+                $location->abbreviation = strtoupper($abbreviation);
+            }
+            else {
+                $location->abbreviation = strtoupper($location->abbreviation);
             }
         });
 

--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -60,6 +60,7 @@ class Location extends BaseModel
                 ->that($location->market_id)->notEmpty('A location must be in a market.')
                 ->verifyNow();
             $location->timezone_id = $location->timezone_id ?: $location->market->timezone->id;
+            $location->abbreviation = strtoupper($location->abbreviation);
 
             if (empty($location->abbreviation)) {
                 do {

--- a/src/Nova/Location.php
+++ b/src/Nova/Location.php
@@ -48,7 +48,9 @@ class Location extends BaseResource
             Text::make('Abbreviation')
                 ->withMeta(['extraAttributes' => ['maxlength' => 4]])
                 ->required(),
-            nova('timezone') ? BelongsTo::make('Timezone', 'timezone', nova('timezone'))->nullable() : null,
+            nova('timezone') ? BelongsTo::make('Timezone', 'timezone', nova('timezone'))
+                ->help('This value will be populated by the corresponding Market if left empty.')
+                ->nullable() : null,
 
             new Panel('Info Fields', $this->infoFields()),
 

--- a/src/Nova/Location.php
+++ b/src/Nova/Location.php
@@ -30,6 +30,11 @@ class Location extends BaseResource
 
     public static $group = 'Locations';
 
+    public function timezone()
+    {
+        return ($this->market->timezone) ? $this->market->timezone->id : null;
+    }
+
     public function fieldsForIndex(NovaRequest $request)
     {
         return array_filter([
@@ -48,7 +53,7 @@ class Location extends BaseResource
             Text::make('Abbreviation')
                 ->withMeta(['extraAttributes' => ['maxlength' => 4]])
                 ->required(),
-            nova('timezone') ? BelongsTo::make('Timezone', 'timezone', nova('timezone'))->required() : null,
+            nova('timezone') ? BelongsTo::make('Timezone', 'timezone', nova('timezone'))->nullable()->default($this->timezone()) : null,
 
             new Panel('Info Fields', $this->infoFields()),
 

--- a/src/Nova/Location.php
+++ b/src/Nova/Location.php
@@ -30,11 +30,6 @@ class Location extends BaseResource
 
     public static $group = 'Locations';
 
-    public function timezone()
-    {
-        return ($this->market->timezone) ? $this->market->timezone->id : null;
-    }
-
     public function fieldsForIndex(NovaRequest $request)
     {
         return array_filter([
@@ -53,7 +48,7 @@ class Location extends BaseResource
             Text::make('Abbreviation')
                 ->withMeta(['extraAttributes' => ['maxlength' => 4]])
                 ->required(),
-            nova('timezone') ? BelongsTo::make('Timezone', 'timezone', nova('timezone'))->nullable()->default($this->timezone()) : null,
+            nova('timezone') ? BelongsTo::make('Timezone', 'timezone', nova('timezone'))->nullable() : null,
 
             new Panel('Info Fields', $this->infoFields()),
 

--- a/src/Nova/Location.php
+++ b/src/Nova/Location.php
@@ -48,9 +48,6 @@ class Location extends BaseResource
             Text::make('Abbreviation')
                 ->withMeta(['extraAttributes' => ['maxlength' => 4]])
                 ->required(),
-            nova('timezone') ? BelongsTo::make('Timezone', 'timezone', nova('timezone'))
-                ->help('This value will be populated by the corresponding Market if left empty.')
-                ->nullable() : null,
 
             new Panel('Info Fields', $this->infoFields()),
 
@@ -76,6 +73,9 @@ class Location extends BaseResource
     {
         return [
             nova('page') ? BelongsTo::make('Page', 'page', nova('page'))->exceptOnForms() : null,
+            nova('timezone') ? BelongsTo::make('Timezone', 'timezone', nova('timezone'))
+                ->help('This value will be populated by the corresponding Market if left empty.')
+                ->nullable() : null,
             nova('domestic_address') ? BelongsTo::make('Domestic Address', 'address', nova('domestic_address'))->nullable() : null,
             nova('phone') ? BelongsTo::make('Phone', 'phone', nova('phone'))->nullable() : null,
             Date::make('Closed At')->nullable(),

--- a/src/Nova/Market.php
+++ b/src/Nova/Market.php
@@ -25,7 +25,7 @@ class Market extends BaseResource
 
     public function title()
     {
-        return $this->name . ', ' . $this->state;
+        return $this->name . ', ' . $this->state->abbreviation;
     }
 
     public static $search = [


### PR DESCRIPTION
Working on improvements to the Location Nova resource:

- [x] Fix Market to only display title + state abbreviation
- [x] Save abbreviation as all uppercase
- [x] Default timezone to Market timezone
- [ ] Add panels for GMB details and hours

Also adding references to Nova resources in this package via https://github.com/tipoff/support/pull/127