### PR TITLE
Exclude 'company' from matching market parameter

### DIFF
--- a/src/LocationsServiceProvider.php
+++ b/src/LocationsServiceProvider.php
@@ -56,8 +56,8 @@ class LocationsServiceProvider extends TipoffServiceProvider
         Route::model('market', Market::class);
         Route::model('location', Location::class);
 
-        // Make sure we dont accidentally steal any nova API routes
-        Route::pattern('market', '^(?!(nova-api|nova-vendor))[^\/]+$');
+        // Make sure we dont accidentally steal any nova API or company routes
+        Route::pattern('market', '^(?!(nova-api|nova-vendor|company))[^\/]+$');
 
         /**
          * Route macro for registering a location based route.  Note the `$routeName`, not the `$uri`,


### PR DESCRIPTION
This conflict hasn't happened yet, so this PR can wait for merge until there's something more meaningful to pull into locations along with it.